### PR TITLE
bind_ad performance changes

### DIFF
--- a/config/auth_ad.php
+++ b/config/auth_ad.php
@@ -30,8 +30,8 @@
 // hosts: an array of AD servers (usually domain controllers) to use for authentication		
 $config['hosts'] = array('mydc01.mydomain.local', 'mydc02.mydomain.local');
 
-// ports: an array containing the remote port number to connect to (default is 389) 
-$config['ports'] = array(389);
+// port: the remote port number to connect to (default is 389) 
+$config['port'] = 389;
 
 // base_dn: the base DN of your Active Directory domain
 $config['base_dn'] = 'DC=mydomain,DC=local';


### PR DESCRIPTION
First sorry for my english (I'm from Uruguay).

I am currently using this library in a study project. In the infrastructure I have three domain controllers, and they are all setted on config file (in $config['hosts'] array). If the first server(s) in the array was down, the execution time of any of the library methods were very high. This is because the timeout of the ldap_connect function is very high.

To resolve this, I added a status check of the servers before to set connection.